### PR TITLE
add binding to synchronous version of exec

### DIFF
--- a/src/Node/ChildProcess.js
+++ b/src/Node/ChildProcess.js
@@ -54,6 +54,16 @@ exports.execSyncImpl = function execSyncImpl (command) {
     };
 };
 
+exports.execFileSyncImpl = function execFileSyncImpl (command) {
+    return function (args) {
+        return function (opts) {
+            return function () {
+                return require('child_process').execFile(command, args, opts);
+            };
+        };
+    };
+};
+
 exports.fork = function fork (cmd) {
     return function (args) {
         return function () {

--- a/src/Node/ChildProcess.js
+++ b/src/Node/ChildProcess.js
@@ -58,7 +58,7 @@ exports.execFileSyncImpl = function execFileSyncImpl (command) {
     return function (args) {
         return function (opts) {
             return function () {
-                return require('child_process').execFile(command, args, opts);
+                return require('child_process').execFileSync(command, args, opts);
             };
         };
     };

--- a/src/Node/ChildProcess.js
+++ b/src/Node/ChildProcess.js
@@ -31,6 +31,7 @@ exports.execImpl = function execImpl (command) {
     };
 };
 
+
 exports.execFileImpl = function execImpl (command) {
     return function (args) {
         return function (opts) {
@@ -41,6 +42,14 @@ exports.execFileImpl = function execImpl (command) {
                     });
                 };
             };
+        };
+    };
+};
+
+exports.execSyncImpl = function execSyncImpl (command) {
+    return function (opts) {
+        return function () {
+            return require('child_process').execSync(command, opts);
         };
     };
 };

--- a/src/Node/ChildProcess.purs
+++ b/src/Node/ChildProcess.purs
@@ -39,6 +39,7 @@ module Node.ChildProcess
   , ExecResult
   , defaultExecOptions
   , execSync
+  , execFileSync
   , ExecSyncOptions
   , defaultExecSyncOptions
   , fork
@@ -340,6 +341,25 @@ execSync cmd opts =
 foreign import execSyncImpl
   :: forall eff
    . String
+  -> ActualExecSyncOptions
+  -> Eff (cp :: CHILD_PROCESS | eff) Buffer
+
+-- | Generally identical to `execFile`, with the exception that 
+-- | the method will not return until the child process has fully closed.
+-- | Returns: The stdout from the command.
+execFileSync
+  :: forall eff
+   .  String
+  -> Array String
+  -> ExecSyncOptions
+  -> Eff (cp :: CHILD_PROCESS | eff) Buffer
+execFileSync cmd args opts =
+  execFileSyncImpl cmd args (convertExecSyncOptions opts)
+
+foreign import execFileSyncImpl
+  :: forall eff
+   . String
+  -> Array String
   -> ActualExecSyncOptions
   -> Eff (cp :: CHILD_PROCESS | eff) Buffer
 


### PR DESCRIPTION
add bindings to [execSync](https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options) and [execFileSync](https://nodejs.org/api/child_process.html#child_process_child_process_execfilesync_file_args_options).