### PR TITLE
`mkOnClose` reacts to the 'close' signal instead of 'exit'

### DIFF
--- a/src/Node/ChildProcess.js
+++ b/src/Node/ChildProcess.js
@@ -69,7 +69,7 @@ exports.mkOnClose = function mkOnClose (mkChildExit) {
     return function onClose (cp) {
         return function (cb) {
             return function () {
-                cp.on('exit', function (code, signal) {
+                cp.on('close', function (code, signal) {
                     cb(mkChildExit(code)(signal))();
                 });
             };


### PR DESCRIPTION
According to the node documentation:
“`'close'` is distinct from the 'exit' event, since multiple processes might
share the same stdio streams.”

https://nodejs.org/api/child_process.html#child_process_event_close

Fixes #15 