### PR TITLE
Update CHANGELOG for v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Other improvements:
 
 ## [v7.0.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v7.0.0) - 2021-MONTH-DAY
 
+Breaking changes:
+  - Updated dependencies for PureScript 0.14 (#25)
+  
 Other improvements:
   - Migrated CI to GitHub Actions and updated installation instructions to use Spago (#24)
   - Added a CHANGELOG.md file and pull request template (#26)
@@ -24,7 +27,7 @@ Other improvements:
 
 ## [v5.0.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v5.0.0) - 2018-06-02
 
-Updates for 0.12
+- Updates for 0.12
 
 **Breaking**
 
@@ -81,7 +84,8 @@ Updates for 0.12
 
 - **Breaking change**:
   - `SpawnOptions` now uses the `Uid` and `Gid` types from `purescript-posix-types` for its `uid` and `gid` options, instead of `Int`.
-- **Additions**:
+  
+- **New features**:
   - Added `exec`.
 
 ## [v0.3.2](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v0.3.2) - 2015-12-27
@@ -114,4 +118,3 @@ Updates for 0.12
 - Update dependencies: `purescript-node-streams` -> `~0.3.0`
 
 See https://github.com/joneshf/purescript-node-child-process/issues/2 for the rationale behind many of these changes.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,15 @@ Bugfixes:
 
 Other improvements:
 
+## [v7.0.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v7.0.0) - 2021-MONTH-DAY
+
+Other improvements:
+  - Migrated CI to GitHub Actions and updated installation instructions to use Spago (#24)
+  - Added a CHANGELOG.md file and pull request template (#26)
+
 ## [v6.0.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v6.0.0) - 2019-03-15
 
-Updated `purescript-foreign-object` dependency
+- Updated `purescript-foreign-object` dependency
 
 ## [v5.0.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v5.0.0) - 2018-06-02
 
@@ -32,7 +38,7 @@ Updates for 0.12
 
 ## [v4.0.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v4.0.0) - 2017-04-05
 
-Updates for 0.11 compiler
+- Updates for 0.11 compiler
 
 ## [v3.0.1](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v3.0.1) - 2016-11-19
 
@@ -48,11 +54,11 @@ Updates for 0.11 compiler
 
 ## [v1.0.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v1.0.0) - 2016-06-19
 
-Updates for 0.9.1 compiler and 1.0 core libraries.
+- Updates for 0.9.1 compiler and 1.0 core libraries.
 
 ## [v0.6.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v0.6.0) - 2016-03-31
 
-Bump dependencies (`purescript-node-streams` -> v0.4.0).
+- Bump dependencies (`purescript-node-streams` -> v0.4.0).
 
 ## [v0.5.1](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v0.5.1) - 2016-01-14
 


### PR DESCRIPTION
**Description of the change**

This PR updates the CHANGELOG in preparation for the v7.0.0 release of this library. We will still need to update dependencies, add that to the CHANGELOG as a breaking change, and then set the correct date before releasing the new version.

Related: purescript/purescript#3985