### PR TITLE
Add shell and encoding options to exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 
 New features:
 
+- Added `shell` and `encoding` options to `exec` functions (#29 by @thomashoneyman)
+
 Bugfixes:
 
 Other improvements:
@@ -15,11 +17,13 @@ Other improvements:
 ## [v7.0.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v7.0.0) - 2021-02-26
 
 Breaking changes:
-  - Updated dependencies for PureScript 0.14 (#25)
-  
+
+- Updated dependencies for PureScript 0.14 (#25)
+
 Other improvements:
-  - Migrated CI to GitHub Actions and updated installation instructions to use Spago (#24)
-  - Added a CHANGELOG.md file and pull request template (#26)
+
+- Migrated CI to GitHub Actions and updated installation instructions to use Spago (#24)
+- Added a CHANGELOG.md file and pull request template (#26)
 
 ## [v6.0.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v6.0.0) - 2019-03-15
 
@@ -83,8 +87,9 @@ Other improvements:
 ## [v0.4.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v0.4.0) - 2015-12-29
 
 - **Breaking change**:
+
   - `SpawnOptions` now uses the `Uid` and `Gid` types from `purescript-posix-types` for its `uid` and `gid` options, instead of `Int`.
-  
+
 - **New features**:
   - Added `exec`.
 

--- a/src/Node/ChildProcess.purs
+++ b/src/Node/ChildProcess.purs
@@ -53,7 +53,7 @@ import Prelude
 
 import Control.Alt ((<|>))
 import Data.Function.Uncurried (Fn2, runFn2)
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Nullable (Nullable, toNullable, toMaybe)
 import Data.Posix (Pid, Gid, Uid)
 import Data.Posix.Signal (Signal)
@@ -64,6 +64,7 @@ import Effect.Exception.Unsafe (unsafeThrow)
 import Foreign (Foreign)
 import Foreign.Object (Object)
 import Node.Buffer (Buffer)
+import Node.Encoding (Encoding, encodingToNode)
 import Node.FS as FS
 import Node.Stream (Readable, Writable, Stream)
 import Unsafe.Coerce (unsafeCoerce)
@@ -334,6 +335,8 @@ convertExecOptions :: ExecOptions -> ActualExecOptions
 convertExecOptions opts = unsafeCoerce
   { cwd: fromMaybe undefined opts.cwd
   , env: fromMaybe undefined opts.env
+  , encoding: maybe undefined encodingToNode opts.encoding
+  , shell: fromMaybe undefined opts.shell
   , timeout: fromMaybe undefined opts.timeout
   , maxBuffer: fromMaybe undefined opts.maxBuffer
   , killSignal: fromMaybe undefined opts.killSignal
@@ -346,6 +349,8 @@ convertExecOptions opts = unsafeCoerce
 type ExecOptions =
   { cwd :: Maybe String
   , env :: Maybe (Object String)
+  , encoding :: Maybe Encoding
+  , shell :: Maybe String
   , timeout :: Maybe Number
   , maxBuffer :: Maybe Int
   , killSignal :: Maybe Signal
@@ -358,6 +363,8 @@ defaultExecOptions :: ExecOptions
 defaultExecOptions =
   { cwd: Nothing
   , env: Nothing
+  , encoding: Nothing
+  , shell: Nothing
   , timeout: Nothing
   , maxBuffer: Nothing
   , killSignal: Nothing

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -23,7 +23,7 @@ main = do
 
   log "doesn't perform effects too early"
   spawn "ls" ["-la"] defaultSpawnOptions >>= \ls -> do
-    let unused = kill SIGTERM ls
+    let _ = kill SIGTERM ls
     onExit ls \exit ->
       case exit of
         Normally 0 ->


### PR DESCRIPTION
**Description of the change**

The Node child process API [supports `shell` and `encoding` arguments for `exec`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback), as well as for [`execFile`](https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback). The latter accepts a `boolean` possibility for `shell`, which I've omitted for ergonomic reasons; it defaults to `false` but setting any shell string will set it to `true`, so it's not strictly necessary to support both forms of the option.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- ~Linked any existing issues or proposals that this pull request should close~
- ~Updated or added relevant documentation~
- ~Added a test for the contribution (if applicable)~
