### PR TITLE
Added shell and timeout, killSignal options to spawn functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 
 New features:
 
+- Added `shell` and `timeout`, `killSignal` options to `spawn` functions
+
 Bugfixes:
 
 Other improvements:

--- a/src/Node/ChildProcess.purs
+++ b/src/Node/ChildProcess.purs
@@ -242,6 +242,9 @@ spawn cmd args = spawnImpl cmd args <<< convertOpts
     { cwd: fromMaybe undefined opts.cwd
     , stdio: toActualStdIOOptions opts.stdio
     , env: toNullable opts.env
+    , shell: fromMaybe undefined opts.shell
+    , timeout: fromMaybe undefined opts.timeout
+    , killSignal: fromMaybe undefined opts.killSignal
     , detached: opts.detached
     , uid: fromMaybe undefined opts.uid
     , gid: fromMaybe undefined opts.gid
@@ -263,6 +266,9 @@ type SpawnOptions =
   { cwd :: Maybe String
   , stdio :: Array (Maybe StdIOBehaviour)
   , env :: Maybe (Object String)
+  , shell :: Maybe String
+  , timeout :: Maybe Number
+  , killSignal :: Maybe Signal
   , detached :: Boolean
   , uid :: Maybe Uid
   , gid :: Maybe Gid
@@ -275,6 +281,9 @@ defaultSpawnOptions =
   { cwd: Nothing
   , stdio: pipe
   , env: Nothing
+  , shell: Nothing
+  , timeout: Nothing
+  , killSignal: Nothing
   , detached: false
   , uid: Nothing
   , gid: Nothing


### PR DESCRIPTION
**Description of the change**

`child_process.spawn` supports `shell` and `timeout`, `killSignal` options 
The `shell` implementation was referenced at https://github.com/purescript-node/purescript-node-child-process/pull/29#issue-942425686.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- ~~Linked any existing issues or proposals that this pull request should close~~
- ~~Updated or added relevant documentation~~
- ~~Added a test for the contribution (if applicable)~~