### PR TITLE
Add pidExists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Breaking changes:
 
 New features:
 - Added `fromKillSignal` (#51 by @JordanMartinez)
+- Added `pidExists` (#52 by @JordanMartinez)
 
 Other improvements:
 - Fix regression: add `ref`/`unref` APIs that were dropped in `v10.0.0` (#50 by @JordanMartinez)

--- a/src/Node/ChildProcess.purs
+++ b/src/Node/ChildProcess.purs
@@ -44,6 +44,7 @@ module Node.ChildProcess
   , stdout
   , stderr
   , pid
+  , pidExists
   , connected
   , disconnect
   , exitCode
@@ -157,6 +158,9 @@ stderr = toUnsafeChildProcess >>> UnsafeCP.unsafeStderr >>> unsafeFromNull
 -- | exited, another process may have taken the same ID, so be careful!
 pid :: ChildProcess -> Effect (Maybe Pid)
 pid = unsafeCoerce SafeCP.pid
+
+pidExists :: ChildProcess -> Effect Boolean
+pidExists = unsafeCoerce SafeCP.pidExists
 
 -- | Indicates whether it is still possible to send and receive
 -- | messages from the child process.

--- a/src/Node/UnsafeChildProcess/Safe.purs
+++ b/src/Node/UnsafeChildProcess/Safe.purs
@@ -10,6 +10,7 @@ module Node.UnsafeChildProcess.Safe
   , messageH
   , spawnH
   , pid
+  , pidExists
   , connected
   , disconnect
   , exitCode
@@ -36,7 +37,7 @@ import Data.Posix.Signal as Signal
 import Effect (Effect)
 import Effect.Uncurried (EffectFn1, EffectFn2, mkEffectFn1, mkEffectFn2, runEffectFn1, runEffectFn2)
 import Foreign (Foreign)
-import Node.ChildProcess.Types (Exit(..), Handle, KillSignal, StdIO, UnsafeChildProcess, ipc, pipe, stringSignal)
+import Node.ChildProcess.Types (Exit(..), Handle, KillSignal, StdIO, UnsafeChildProcess, intSignal, ipc, pipe, stringSignal)
 import Node.Errors.SystemError (SystemError)
 import Node.EventEmitter (EventEmitter, EventHandle(..))
 import Node.EventEmitter.UtilTypes (EventHandle0, EventHandle1)
@@ -78,6 +79,9 @@ pid :: UnsafeChildProcess -> Effect (Maybe Pid)
 pid cp = map toMaybe $ runEffectFn1 pidImpl cp
 
 foreign import pidImpl :: EffectFn1 (UnsafeChildProcess) (Nullable Pid)
+
+pidExists :: UnsafeChildProcess -> Effect Boolean
+pidExists cp = kill' (intSignal 0) cp
 
 -- | Indicates whether it is still possible to send and receive
 -- | messages from the child process.

--- a/src/Node/UnsafeChildProcess/Safe.purs
+++ b/src/Node/UnsafeChildProcess/Safe.purs
@@ -80,6 +80,8 @@ pid cp = map toMaybe $ runEffectFn1 pidImpl cp
 
 foreign import pidImpl :: EffectFn1 (UnsafeChildProcess) (Nullable Pid)
 
+-- | Note: this will not work if the user does not have permission to kill
+-- | a `PID`. Uses `cp.kill(0)` underneath.
 pidExists :: UnsafeChildProcess -> Effect Boolean
 pidExists cp = kill' (intSignal 0) cp
 


### PR DESCRIPTION
**Description of the change**

Adds `pidExists`. Note: this won't work if the user doesn't have permission to `kill` a PID.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
