### PR TITLE
Fix remaining issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ Bugfixes:
 
 Other improvements:
 
+## [v12.0.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v12.0.0) - 2023-07-26
+
+Breaking changes:
+- Removed `safeStdio` (#60 by @JordanMartinez)
+
+  Turns out this isn't safe for `*Sync` functions. AFAIK, this isn't documented
+  in Node docs.
+
+Bugfixes:
+- Fixed `exitH`'s String value for listener (#60 by @JordanMartinez)
+- Added missing FFI for `execSync'` (#60 by @JordanMartinez)
+- Fixed `fromKillSignal`'s FFI's arg order (#60 by @JordanMartinez)
+
+Other improvements:
+- Update tests to actually throw if invalid state occurs (#60 by @JordanMartinez)
+
 ## [v11.0.0](https://github.com/purescript-node/purescript-node-child-process/releases/tag/v11.0.0) - 2023-07-25
 
 Breaking changes:

--- a/src/Node/ChildProcess/Types.js
+++ b/src/Node/ChildProcess/Types.js
@@ -1,8 +1,8 @@
 export const showKillSignal = (ks) => ks + "";
 export const showShell = (shell) => shell + "";
-export const fromKillSignalImpl = (left, right, sig) => {
+export const fromKillSignalImpl = (fromInt, fromStr, sig) => {
   const ty = typeof sig;
-  if (ty === "number") return right(sig | 0);
-  if (ty === "string") return left(sig);
+  if (ty === "number") return fromInt(sig | 0);
+  if (ty === "string") return fromStr(sig);
   throw new Error("Impossible. Got kill signal that was neither int nor string: " + sig);
 };

--- a/src/Node/UnsafeChildProcess/Safe.purs
+++ b/src/Node/UnsafeChildProcess/Safe.purs
@@ -24,7 +24,6 @@ module Node.UnsafeChildProcess.Safe
   , spawnFile
   , spawnArgs
   , stdio
-  , safeStdio
   ) where
 
 import Prelude
@@ -37,7 +36,7 @@ import Data.Posix.Signal as Signal
 import Effect (Effect)
 import Effect.Uncurried (EffectFn1, EffectFn2, mkEffectFn1, mkEffectFn2, runEffectFn1, runEffectFn2)
 import Foreign (Foreign)
-import Node.ChildProcess.Types (Exit(..), Handle, KillSignal, StdIO, UnsafeChildProcess, intSignal, ipc, pipe, stringSignal)
+import Node.ChildProcess.Types (Exit(..), Handle, KillSignal, StdIO, UnsafeChildProcess, intSignal, stringSignal)
 import Node.Errors.SystemError (SystemError)
 import Node.EventEmitter (EventEmitter, EventHandle(..))
 import Node.EventEmitter.UtilTypes (EventHandle0, EventHandle1)
@@ -149,10 +148,3 @@ foreign import spawnArgs :: UnsafeChildProcess -> Array String
 foreign import spawnFile :: UnsafeChildProcess -> String
 
 foreign import stdio :: UnsafeChildProcess -> Array StdIO
-
--- | Safe default configuration for an UnsafeChildProcess.
--- | `[ pipe, pipe, pipe, ipc ]`.
--- | Creates a new stream for `stdin`, `stdout`, and `stderr`
--- | Also adds an IPC channel, even if it's not used.
-safeStdio :: Array StdIO
-safeStdio = [ pipe, pipe, pipe, ipc ]

--- a/src/Node/UnsafeChildProcess/Safe.purs
+++ b/src/Node/UnsafeChildProcess/Safe.purs
@@ -61,7 +61,7 @@ errorH :: EventHandle1 UnsafeChildProcess SystemError
 errorH = EventHandle "error" mkEffectFn1
 
 exitH :: EventHandle UnsafeChildProcess (Exit -> Effect Unit) (EffectFn2 (Nullable Int) (Nullable KillSignal) Unit)
-exitH = EventHandle "exitH" \cb -> mkEffectFn2 \code signal ->
+exitH = EventHandle "exit" \cb -> mkEffectFn2 \code signal ->
   case toMaybe code, toMaybe signal of
     Just c, _ -> cb $ Normally c
     _, Just s -> cb $ BySignal s

--- a/src/Node/UnsafeChildProcess/Unsafe.js
+++ b/src/Node/UnsafeChildProcess/Unsafe.js
@@ -16,7 +16,7 @@ export {
   spawnSync as spawnSyncOptsImpl,
   fork as forkImpl,
   fork as forkOptsImpl,
-} from "child_process";
+} from "node:child_process";
 
 export const unsafeStdin = (cp) => cp.stdin;
 export const unsafeStdout = (cp) => cp.stdout;

--- a/src/Node/UnsafeChildProcess/Unsafe.js
+++ b/src/Node/UnsafeChildProcess/Unsafe.js
@@ -10,6 +10,7 @@ export {
   spawn as spawnImpl, 
   spawn as spawnOptsImpl, 
   execSync as execSyncImpl,
+  execSync as execSyncOptsImpl,
   execFileSync as execFileSyncImpl,
   execFileSync as execFileSyncOptsImpl,
   spawnSync as spawnSyncImpl,

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,16 +10,15 @@ import Effect (Effect)
 import Effect.Aff (Aff, effectCanceler, launchAff_, makeAff, nonCanceler)
 import Effect.Class (liftEffect)
 import Effect.Class.Console (log)
-import Effect.Exception (throwException)
+import Effect.Exception (throw, throwException)
 import Node.Buffer as Buffer
-import Node.ChildProcess (exec', execSync', kill, spawn, stdin, stdout)
+import Node.ChildProcess (exec', execSync', kill, spawn, stdin)
 import Node.ChildProcess as CP
+import Node.ChildProcess.Aff (waitSpawned)
 import Node.ChildProcess.Types (Exit(..), fromKillSignal)
 import Node.Encoding (Encoding(..))
 import Node.Encoding as NE
-import Node.Errors.SystemError (code)
-import Node.EventEmitter (EventHandle, on_, once, once_)
-import Node.Stream (dataH)
+import Node.EventEmitter (EventHandle, once, once_)
 import Node.Stream as Stream
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -64,17 +63,24 @@ spawnLs :: Aff Unit
 spawnLs = do
   log "\nspawns processes ok"
   ls <- liftEffect $ spawn "ls" [ "-la" ]
-  liftEffect $ (stdout ls) # on_ dataH (Buffer.toString UTF8 >=> log)
-  exit <- until ls CP.exitH \complete -> \exit -> complete exit
-  log $ "ls exited: " <> show exit
+  res <- waitSpawned ls
+  case res of
+    Right pid -> log $ "ls successfully spawned with PID: " <> show pid
+    Left err -> liftEffect $ throwException $ unsafeCoerce err
+  exit <- until ls CP.closeH \complete -> \exit -> complete exit
+  case exit of
+    Normally 0 -> log $ "ls exited with 0"
+    Normally i -> liftEffect $ throw $ "ls had non-zero exit: " <> show i
+    BySignal sig -> liftEffect $ throw $ "ls exited with sig: " <> show sig
 
 nonExistentExecutable :: Aff Unit
 nonExistentExecutable = do
   log "\nemits an error if executable does not exist"
   ch <- liftEffect $ spawn "this-does-not-exist" []
-  err <- until ch CP.errorH \complete -> \err -> complete err
-  log (code err)
-  log "nonexistent executable: all good."
+  res <- waitSpawned ch
+  case res of
+    Left _ -> log "nonexistent executable: all good."
+    Right pid -> liftEffect $ throw $ "nonexistent executable started with PID: " <> show pid
 
 noEffectsTooEarly :: Aff Unit
 noEffectsTooEarly = do
@@ -85,8 +91,8 @@ noEffectsTooEarly = do
   case exit of
     Normally 0 ->
       log "All good!"
-    _ -> do
-      log ("Bad exit: expected `Normally 0`, got: " <> show exit)
+    _ ->
+      liftEffect $ throw $ "Bad exit: expected `Normally 0`, got: " <> show exit
 
 killsProcess :: Aff Unit
 killsProcess = do
@@ -98,7 +104,7 @@ killsProcess = do
     BySignal s | Just SIGTERM <- Signal.fromString =<< (hush $ fromKillSignal s) ->
       log "All good!"
     _ -> do
-      log ("Bad exit: expected `BySignal SIGTERM`, got: " <> show exit)
+      liftEffect $ throw $ "Bad exit: expected `BySignal SIGTERM`, got: " <> show exit
 
 execLs :: Aff Unit
 execLs = do
@@ -107,7 +113,13 @@ execLs = do
     -- returned ChildProcess is ignored here
     void $ exec' "ls >&2" identity (done <<< Right)
     pure nonCanceler
-  log "redirected to stderr:" *> (liftEffect $ Buffer.toString UTF8 r.stderr >>= log)
+  stdout' <- liftEffect $ Buffer.toString UTF8 r.stdout
+  stderr' <- liftEffect $ Buffer.toString UTF8 r.stderr
+  when (stdout' /= "") do
+    liftEffect $ throw $ "stdout should be redirected to stderr but had content: " <> show stdout'
+  when (stderr' == "") do
+    liftEffect $ throw $ "stderr should have content but was empty"
+  log "stdout was successfully redirected to stderr"
 
 execSyncEcho :: String -> Aff Unit
 execSyncEcho str = liftEffect do
@@ -115,4 +127,6 @@ execSyncEcho str = liftEffect do
   buf <- Buffer.fromString str UTF8
   resBuf <- execSync' "cat" (_ { input = Just buf })
   res <- Buffer.toString NE.UTF8 resBuf
-  log res
+  when (str /= res) do
+    throw $ "cat did not output its input. \nGot: " <> show res <> "\nExpected: " <> show str
+  log "cat successfully re-outputted its input"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -46,11 +46,15 @@ until ee event cb = makeAff \done -> do
 writingToStdinWorks :: Aff Unit
 writingToStdinWorks = do
   log "\nwriting to stdin works"
-  sp <- liftEffect $ spawn "sh" [ "./sleep.sh" ]
+  sp <- liftEffect $ spawn "sh" [ "./test/sleep.sh" ]
   liftEffect do
+    (stdin sp) # once_ Stream.errorH \err -> do
+      log "Error in stdin"
+      throwException $ unsafeCoerce err
     buf <- Buffer.fromString "helllo" UTF8
     void $ Stream.write (stdin sp) buf
-    sp # once_ CP.errorH \err ->
+    sp # once_ CP.errorH \err -> do
+      log "Error in child process"
       throwException $ unsafeCoerce err
   exit <- until sp CP.closeH \completeAff -> \exit ->
     completeAff exit

--- a/test/sleep.sh
+++ b/test/sleep.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+sleep 2000
+echo "$1"
+
+echo "Done"

--- a/test/sleep.sh
+++ b/test/sleep.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-sleep 2000
+sleep 2
 echo "$1"
 
 echo "Done"


### PR DESCRIPTION
**Description of the change**

- Updates tests to use `Aff`, so rather than printing something we then manually check is correct, an exception is thrown if the expected state isn't hit.
- Fix `exitH`'s string value
- Add missing `FFI` for `execSync'`
- Drop `ipc` on `*Sync` functions (error at runtime if used in this way)
- Drop `safeStdio`, inline it
- Fix `fromKillSignal` FFI arg order

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
